### PR TITLE
Updated models.py to use timezone safe datetime

### DIFF
--- a/undelete/models.py
+++ b/undelete/models.py
@@ -1,6 +1,9 @@
-from datetime import datetime
 from django.db import models
 from django.utils.translation import ugettext_lazy as _
+try:
+    from django.utils import timezone as datetime
+except ImportError:
+    from datetime import datetime
 
 from undelete.managers import TrashedManager, NonTrashedManager
 


### PR DESCRIPTION
Updated models.py to use timezone safe datetime in django if available, otherwise fallback to the standard datetime. Maintains backwards compatibility with Django 1.3.
